### PR TITLE
EDID: improved debugging and 2 patches

### DIFF
--- a/arch/arm/plat-rk/rk-sdmmc-wifi.c
+++ b/arch/arm/plat-rk/rk-sdmmc-wifi.c
@@ -99,8 +99,12 @@ static void *wifi_status_cb_devid;
 
 struct rksdmmc_gpio_wifi_moudle  rk_platform_wifi_gpio = {
     .power_n = {
-            .io             = RK30SDK_WIFI_GPIO_POWER_N, 
-            .enable         = RK30SDK_WIFI_GPIO_POWER_ENABLE_VALUE,
+			#ifdef RK30SDK_WIFI_GPIO_POWER_N
+    		.io             = RK30SDK_WIFI_GPIO_POWER_N,
+			#endif
+			#ifdef RK30SDK_WIFI_GPIO_POWER_ENABLE_VALUE
+    		.enable         = RK30SDK_WIFI_GPIO_POWER_ENABLE_VALUE,
+			#endif
             #ifdef RK30SDK_WIFI_GPIO_POWER_PIN_NAME
             .iomux          = {
                 .name       = RK30SDK_WIFI_GPIO_POWER_PIN_NAME,

--- a/drivers/net/usb/Kconfig
+++ b/drivers/net/usb/Kconfig
@@ -291,6 +291,44 @@ config USB_NET_MCS7830
 	  Choose this option if you're using a 10/100 Ethernet USB2
 	  adapter based on the MosChip 7830 controller. This includes
 	  adapters marketed under the DeLOCK brand.
+	  
+config USB_NET_MCS7830_FILIPPOG_FIX
+    bool "Fillipo_G's fix for some MosChip MCS7830 based Ethernet adapters"
+	help
+	  Fillipo_G's or gen2thomas's fix is necessary for some MosChip MCS7830 based 
+	  Ethernet adapters in case of the driver (mcs7830.ko) is loaded
+	  but no network connection/traffic is possible. Please choose only one of 
+	  this patches! The activation of both patches should be possible but slow down your 
+	  connection unnecessarily.
+	  
+	  Fillipo_G's fix for that bug is slightly slower than gen2thomas's fix but a little 
+	  bit more tested. You can start with gen2thomas's fix activated but in case of some
+	  problems please give feedback and switch temporarely to the Fillipo_G's patch variant.
+
+	  The actual implementation of both patches also affects the other
+	  drivers using the USB_NET framework.
+
+	  For more information see:
+	  https://www.miniand.com/forums/forums/picuntu-linux/topics/no-update-no-download-no-adress-associated-with-hostname?page=2
+
+config USB_NET_MCS7830_GEN2THOMAS_FIX
+    bool "gen2thomas's fix for some MosChip MCS7830 based Ethernet adapters"
+	help
+	  Fillipo_G's or gen2thomas's fix is necessary for some MosChip MCS7830 based 
+	  Ethernet adapters in case of the driver (mcs7830.ko) is loaded
+	  but no network connection/traffic is possible. Please choose only one of 
+	  this patches! The activation of both patches should be possible but slow down your 
+	  connection unnecessarily.
+	  
+	  Fillipo_G's fix for that bug is slightly slower than gen2thomas's fix but a little 
+	  bit more tested. You can start with gen2thomas's fix activated but in case of some
+	  problems please give feedback and switch temporarely to the Fillipo_G's patch variant.
+
+	  The actual implementation of both patches also affects the other
+	  drivers using the USB_NET framework.
+
+	  For more information see:
+	  https://www.miniand.com/forums/forums/picuntu-linux/topics/no-update-no-download-no-adress-associated-with-hostname?page=2
 
 config USB_NET_RNDIS_HOST
 	tristate "Host for RNDIS and ActiveSync devices (EXPERIMENTAL)"

--- a/drivers/usb/dwc_otg/dwc_otg_hcd.c
+++ b/drivers/usb/dwc_otg/dwc_otg_hcd.c
@@ -3324,6 +3324,8 @@ void dwc_otg_clear_halt(struct urb *_urb)
 		_qh->data_toggle = 0;
 	}
 }
+EXPORT_SYMBOL_GPL(dwc_otg_clear_halt);
+
 /*
  * Returns the Queue Head for an URB.
  */

--- a/drivers/usb/dwc_otg/dwc_otg_rk29/dwc_otg_hcd.c
+++ b/drivers/usb/dwc_otg/dwc_otg_rk29/dwc_otg_hcd.c
@@ -3303,6 +3303,7 @@ void dwc_otg_clear_halt(struct urb *_urb)
 		_qh->data_toggle = 0;
 	}
 }
+EXPORT_SYMBOL_GPL(dwc_otg_clear_halt);
 /*
  * Returns the Queue Head for an URB.
  */

--- a/drivers/video/fbmon.c
+++ b/drivers/video/fbmon.c
@@ -41,9 +41,7 @@
  * EDID parser
  */
 
-#undef DEBUG  /* define this for verbose EDID parsing output */
-
-#ifdef DEBUG
+#ifdef CONFIG_BASIC_EDID_DEBUG
 #define DPRINTK(fmt, args...) printk(fmt,## args)
 #else
 #define DPRINTK(fmt, args...)
@@ -579,6 +577,7 @@ static void get_detailed_timing(unsigned char *block,
 	}
 	mode->flag = FB_MODE_IS_DETAILED;
 
+	DPRINTK("    %dx%d@%d:\n", H_ACTIVE, V_ACTIVE, PIXEL_CLOCK/((H_ACTIVE + H_BLANKING) * (V_ACTIVE + V_BLANKING)));
 	DPRINTK("      %d MHz ",  PIXEL_CLOCK/1000000);
 	DPRINTK("%d %d %d %d ", H_ACTIVE, H_ACTIVE + H_SYNC_OFFSET,
 	       H_ACTIVE + H_SYNC_OFFSET + H_SYNC_WIDTH, H_ACTIVE + H_BLANKING);
@@ -938,7 +937,7 @@ void fb_edid_to_monspecs(unsigned char *edid, struct fb_monspecs *specs)
 	specs->revision = edid[EDID_STRUCT_REVISION];
 
 	DPRINTK("========================================\n");
-	DPRINTK("Display Information (EDID)\n");
+	DPRINTK("Display Information (EDID)         start\n");
 	DPRINTK("========================================\n");
 	DPRINTK("   EDID Version %d.%d\n", (int) specs->version,
 	       (int) specs->revision);
@@ -979,7 +978,7 @@ void fb_edid_to_monspecs(unsigned char *edid, struct fb_monspecs *specs)
 	if (!found)
 		specs->misc &= ~FB_MISC_1ST_DETAIL;
 
-	DPRINTK("========================================\n");
+	DPRINTK("================end==================\n");
 }
 
 /**

--- a/drivers/video/rockchip/Kconfig
+++ b/drivers/video/rockchip/Kconfig
@@ -7,6 +7,56 @@ menuconfig FB_ROCKCHIP
         ---help---
           Framebuffer driver for rockchip based platform
 
+config EDID_BASICTOSVD_GEN2THOMAS_FIX
+	bool     "EDID fix by gen2thomas to make all resolutions available"
+  help
+   This fix ensure that all resolutions from basic EDID block of your display 
+   are also available for your device. In case the extended EDID block of your 
+   display has some SVD's (short video descriptor) the basic EDID block 
+   informations will be lost without this fix.
+   
+   Background: Some monitors EDID (f.e. acer P225HQL) have no duplicated entry in basic and
+   extended block. F.e. the 1920x1080p resolution is only described in the basic EDID block 
+   and some other resolutions are available as SVD of the extended EDID block.
+   Therefore the 1920x1080p resolution (or possible others) will be lost although the monitor
+   would support it.
+
+config BASIC_EDID_DEBUG
+	bool "EDID debug output of basic block"
+	default n
+	help
+	  Say Y here if you want the EDID driver to output all sorts
+	  of debugging information to provide to the maintainer when
+	  something goes wrong.
+	  
+	  Set this to Y in case you need more informations about parsing the 
+	  basic EDID block (first 128 bytes). Also some informations of the
+	  not already completed implementation of (extended) E-EDID block 
+	  could be displayed.
+
+config HDMI_EDID_DEBUG
+	bool "HDMI EDID debug output"
+	default n
+	help
+	  Say Y here if you want the HDMI-EDID driver part to output all sorts
+	  of debugging information to provide to the maintainer when
+	  something goes wrong.
+	  
+	  Set this to Y in case you need more informations about the 
+	  (extended) E-EDID block parsing. Also the binary content of the basic buffer
+	  will be shown.
+	  
+config HDMI_LCDC_EDID_DEBUG
+	bool "HDMI LCDC EDID debug output"
+	default n
+	help
+	  Say Y here if you want the HDMI-LCDC-EDID driver part to output all sorts
+	  of debugging information to provide to the maintainer when
+	  something goes wrong.
+	  
+	  Set this to Y will cause more informations about the using of
+	  parsed EDID for your device. "Show Sink Info" is part of this output. 
+
 config FB_MIRRORING
 	bool     "Mirroring support"
 	depends on FB_ROCKCHIP

--- a/drivers/video/rockchip/Kconfig
+++ b/drivers/video/rockchip/Kconfig
@@ -20,6 +20,18 @@ config EDID_BASICTOSVD_GEN2THOMAS_FIX
    and some other resolutions are available as SVD of the extended EDID block.
    Therefore the 1920x1080p resolution (or possible others) will be lost although the monitor
    would support it.
+   
+config EDID_FINDBESTMODE_GEN2THOMAS_FIX
+	bool     "EDID fix by gen2thomas to find best mode also for not sorted lists"
+  help
+   This patch get the best mode from the given list also in the case that the list is not sorted 
+   correctly and also for the case that the highest resolution not match the given ratio of the
+   screen. In that case the best resolution for the matching ratio to the screen is used. Also 
+   for two equivalent resolutions the mode with the higher frequency is found and used. 
+   
+   Background: The original method only differentiate between two cases. But the real world know
+   nine cases (three for x, three for y and the combinations). The patched algorithm know and match 
+   all nine cases. 
 
 config BASIC_EDID_DEBUG
 	bool "EDID debug output of basic block"

--- a/drivers/video/rockchip/hdmi/rk_hdmi.h
+++ b/drivers/video/rockchip/hdmi/rk_hdmi.h
@@ -15,6 +15,16 @@
 #define HDMI_VIC_MASK					(0xFF)
 #define HDMI_TYPE_MASK					(0xFF << 8)
 
+#ifdef CONFIG_EDID_FINDBESTMODE_GEN2THOMAS_FIX //EDID fix by gen2thomas to find best mode also for not sorted lists
+enum hdmi_known_ratio{
+	HDMI_16_BY_09 = 178, // HD video standard 16:9 = 1.78 (widescreen)
+	HDMI_16_BY_10 = 160, // 16:10 = 1,6, f.e. 1280x800, 1680x1050
+	HDMI_04_BY_03 = 133, // standard television format 4:3 = 1.33
+	HDMI_05_BY_04 = 125, // 5:4 = 1.25, f.e. 1280x1024
+};
+
+#endif
+
 // HDMI video information code according CEA-861-E
 enum hdmi_video_infomation_code {
 	HDMI_640x480p_60HZ = 1,
@@ -213,7 +223,7 @@ struct hdmi_edid {
 	unsigned char deepcolor;			//bit3:DC_48bit; bit2:DC_36bit; bit1:DC_30bit; bit0:DC_Y444;
 	unsigned int  cecaddress;			//CEC physical address
 	unsigned int  maxtmdsclock;			//Max supported tmds clock
-	unsigned char fields_present;		//bit7£ºlatency£»bit6£ºi_lantency£»bit5£ºhdmi_video
+	unsigned char fields_present;		//bit7ï¿½ï¿½latencyï¿½ï¿½bit6ï¿½ï¿½i_lantencyï¿½ï¿½bit5ï¿½ï¿½hdmi_video
 	unsigned char video_latency;
 	unsigned char audio_latency;
 	unsigned char interlaced_video_latency;


### PR DESCRIPTION
1.) made some improvements for debugging of EDID, all three levels are configurable via .config:
CONFIG_BASIC_EDID_DEBUG = y
CONFIG_HDMI_EDID_DEBUG = y
CONFIG_HDMI_LCDC_EDID_DEBUG = y

2.) patch the case that the basic EDID block contains the preferred timing (was not used before in case some SVD was also present at the same time)
CONFIG_EDID_BASICTOSVD_GEN2THOMAS_FIX = y

3.) patch the unstable and incomplete method to find best mode
CONFIG_EDID_FINDBESTMODE_GEN2THOMAS_FIX = y

For patch (2) see also: https://www.miniand.com/forums/forums/picuntu-linux/topics/how-to-change-the-resolution?page=2

For patch (3) see also: http://www.freaktab.com/showthread.php?7208-1080p-Kernel-for-broken-EDID-Screens&amp;p=117281&amp;viewfull=1#post117281
