### PR TITLE
rk_fb, rk*_lcdc: Return -NOIOCTLCMD for unsupported ioctl cmds

### DIFF
--- a/drivers/video/rockchip/lcdc/rk2928_lcdc.c
+++ b/drivers/video/rockchip/lcdc/rk2928_lcdc.c
@@ -802,7 +802,7 @@ int rk2928_lcdc_ioctl(struct rk_lcdc_device_driver * dev_drv,unsigned int cmd, u
 				return -EFAULT;
 			break;
 		default:
-			break;
+			return -ENOIOCTLCMD;
 	}
 
 	return ret;

--- a/drivers/video/rockchip/lcdc/rk3066b_lcdc.c
+++ b/drivers/video/rockchip/lcdc/rk3066b_lcdc.c
@@ -666,7 +666,7 @@ int rk3066b_lcdc_ioctl(struct rk_lcdc_device_driver * dev_drv,unsigned int cmd, 
 				return -EFAULT;
 			break;
 		default:
-			break;
+			return -ENOIOCTLCMD;
 	}
 
 	return ret;

--- a/drivers/video/rockchip/lcdc/rk30_lcdc.c
+++ b/drivers/video/rockchip/lcdc/rk30_lcdc.c
@@ -1088,7 +1088,7 @@ int rk30_lcdc_ioctl(struct rk_lcdc_device_driver * dev_drv,unsigned int cmd, uns
 			break;
 #endif
 		default:
-			break;
+			return -ENOIOCTLCMD;
 	}
 
 	return ret;

--- a/drivers/video/rockchip/lcdc/rk3188_lcdc.c
+++ b/drivers/video/rockchip/lcdc/rk3188_lcdc.c
@@ -914,7 +914,7 @@ static int rk3188_lcdc_ioctl(struct rk_lcdc_device_driver *dev_drv, unsigned int
 			}
 			break;
 		default:
-			break;
+			return -ENOIOCTLCMD;
 	}
 	return 0;
 }


### PR DESCRIPTION
rk_fb_ioctl returned 0 for unhandled commands, which means success.

One example of a major problem caused by this is when using
xf86-video-fbturbo, which probes for a non-standard ioctl. Since it
reads back a 'success' code, it then thinks the framebuffer device
supports DMA accelerated copyarea operations, which it attemps to
use. Since this feature is not actually supported, this causes
visual glitches.
